### PR TITLE
Fix example asset paths in UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -524,8 +524,8 @@ def gpu_wrapped_execute_image(*args, **kwargs):
 
 
 # assets
-example_portrait_dir = "assets/examples/source"
-example_video_dir = "assets/examples/driving"
+example_portrait_dir = "assets/source"
+example_video_dir = "assets/driving"
 data_examples = [
     [osp.join(example_portrait_dir, "s9.jpg"), osp.join(example_video_dir, "d0.mp4"), True, True, True, False],
     [osp.join(example_portrait_dir, "s6.jpg"), osp.join(example_video_dir, "d0.mp4"), True, True, True, False],


### PR DESCRIPTION
The example assets for the UI were moved from `assets/examples` to `assets`, but the `app.py` configuration was not updated. This correctly updates the `example_portrait_dir` and `example_video_dir` paths in `app.py` so the UI examples load properly.

---
*PR created automatically by Jules for task [5258907508352480638](https://jules.google.com/task/5258907508352480638) started by @LebToki*