### PR TITLE
🔒 Fix RCE vulnerability in framerate parsing

### DIFF
--- a/submit_wrapper.py
+++ b/submit_wrapper.py
@@ -1,0 +1,15 @@
+import sys
+
+branch_name = 'jules-151106930138509494-2adecaca'
+commit_message = '🔒 Fix RCE vulnerability in framerate parsing\n\nReplaced eval() with safe string splitting for fps parsing.'
+title = '🔒 Fix RCE vulnerability in framerate parsing'
+description = """🎯 **What:** The vulnerability fixed
+The code was using `eval()` to parse framerate strings from ffprobe JSON output, which allows for remote code execution if an attacker provides a crafted video file with a malicious `r_frame_rate`.
+
+⚠️ **Risk:** The potential impact if left unfixed
+An attacker could upload a video to PresentaPulse which contains arbitrary Python code embedded in its frame rate metadata, which would be executed by the `eval()` function with the privileges of the application process.
+
+🛡️ **Solution:** How the fix addresses the vulnerability
+Replaced the use of `eval()` with string splitting on `/` and simple float division, a safe alternative that avoids code execution entirely while maintaining the intended functionality."""
+
+print(f"I will submit with branch: {branch_name}")

--- a/video_enhanced.py
+++ b/video_enhanced.py
@@ -120,7 +120,11 @@ def get_video_info(video_path):
         if 'streams' in info and len(info['streams']) > 0:
             stream = info['streams'][0]
             fps_str = stream.get('r_frame_rate', '30/1')
-            fps = eval(fps_str) if '/' in fps_str else float(fps_str)
+            if '/' in fps_str:
+                num, den = fps_str.split('/', 1)
+                fps = float(num) / float(den) if float(den) != 0 else 0.0
+            else:
+                fps = float(fps_str)
             return {
                 'width': stream.get('width', 512),
                 'height': stream.get('height', 512),


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed\nThe code was using `eval()` to parse framerate strings from ffprobe JSON output, which allows for remote code execution if an attacker provides a crafted video file with a malicious `r_frame_rate`.\n\n⚠️ **Risk:** The potential impact if left unfixed\nAn attacker could upload a video to PresentaPulse which contains arbitrary Python code embedded in its frame rate metadata, which would be executed by the `eval()` function with the privileges of the application process.\n\n🛡️ **Solution:** How the fix addresses the vulnerability\nReplaced the use of `eval()` with string splitting on `/` and simple float division, a safe alternative that avoids code execution entirely while maintaining the intended functionality.

---
*PR created automatically by Jules for task [151106930138509494](https://jules.google.com/task/151106930138509494) started by @LebToki*