### PR TITLE
🔒 Disable public Gradio sharing

### DIFF
--- a/app.py
+++ b/app.py
@@ -2042,7 +2042,7 @@ with gr.Blocks(theme=theme, css=custom_css, title="PresentaPulse - LivePortrait 
 
 demo.launch(
     # server_port=args.server_port,
-    share=True,
+    share=False,
     server_name=args.server_name,
     server_port=8080  # Specify a different port here
 )


### PR DESCRIPTION
* 🎯 **What:** The Gradio application was publicly exposed because the `share=True` flag was used in `demo.launch()`.
* ⚠️ **Risk:** Running the server with `share=True` allows anyone with the generated Gradio link to access the interface, potentially executing features and causing denial of service or accessing private outputs.
* 🛡️ **Solution:** Disabled the public share option by setting `share=False`.

---
*PR created automatically by Jules for task [12878148406255684924](https://jules.google.com/task/12878148406255684924) started by @LebToki*